### PR TITLE
feat: add go to definition for imports

### DIFF
--- a/src/definition.rs
+++ b/src/definition.rs
@@ -12,22 +12,15 @@ pub fn get_definitions(
     match kind {
         IndexEntryKind::FlagValue(flag_nr) => {
             let flag = &line.flags[*flag_nr];
-            if Option::is_none(&line.command) {
-                return None;
-            }
+            let command_name = &line.command?.0;
             if line.flags.len() != 1 {
                 return None;
             }
-            let command_name = &line.command.as_ref().unwrap().0;
             if *command_name != "import" && *command_name != "try-import" {
                 return None;
             }
 
-            if Option::is_none(&flag.value) {
-                return None;
-            }
-
-            let flag_value = &flag.value.as_ref().unwrap().0;
+            let flag_value = &flag.value?.0;
             let path = resolve_bazelrc_path(file_path, flag_value)?;
             let url = Url::from_file_path(path).ok()?;
             Some(GotoDefinitionResponse::Scalar(Location {

--- a/src/definition.rs
+++ b/src/definition.rs
@@ -1,0 +1,49 @@
+use std::path::Path;
+
+use tower_lsp::lsp_types::*;
+
+use crate::{file_utils::resolve_bazelrc_path, line_index::IndexEntryKind, parser::Line};
+
+pub fn get_definitions(
+    file_path: &Path,
+    kind: &IndexEntryKind,
+    line: &Line,
+) -> Option<GotoDefinitionResponse> {
+    match kind {
+        IndexEntryKind::FlagValue(flag_nr) => {
+            let flag = &line.flags[*flag_nr];
+            if Option::is_none(&line.command) {
+                return None;
+            }
+            if line.flags.len() != 1 {
+                return None;
+            }
+            let command_name = &line.command.as_ref().unwrap().0;
+            if *command_name != "import" && *command_name != "try-import" {
+                return None;
+            }
+
+            if Option::is_none(&flag.value) {
+                return None;
+            }
+
+            let flag_value = &flag.value.as_ref().unwrap().0;
+            let path = resolve_bazelrc_path(file_path, flag_value)?;
+            let url = Url::from_file_path(path).ok()?;
+            Some(GotoDefinitionResponse::Scalar(Location {
+                uri: url,
+                range: Range {
+                    start: Position {
+                        line: 0,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 0,
+                        character: 0,
+                    },
+                },
+            }))
+        }
+        _ => None,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod bazel_flags;
 pub mod completion;
+pub mod definition;
 pub mod diagnostic;
 pub mod file_utils;
 pub mod formatting;


### PR DESCRIPTION
Adds the go to definition capability for navigating to import files. This functionality already exists via document link, but I think it's more/also appropriate as a definition.
I can also imagine going to definition for flag aliases as well as targets in the future.
